### PR TITLE
Add ethnicity breakdown and codelist

### DIFF
--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -1,0 +1,15 @@
+from ehrql import codelist_from_csv
+
+# Import pharmacy first conditions codelist
+pharmacy_first_conditions_codelist = codelist_from_csv(
+    "codelists/user-chriswood-pharmacy-first-clinical-pathway-conditions.csv",
+    column="code",
+    category_column="term",
+)
+
+# Import ethnicity codelist
+ethnicity_codelist = codelist_from_csv(
+    "codelists/opensafely-ethnicity-snomed-0removed.csv",
+    column="snomedcode",
+    category_column="Grouping_6",
+)

--- a/codelists/codelists.json
+++ b/codelists/codelists.json
@@ -5,6 +5,12 @@
       "url": "https://www.opencodelists.org/codelist/user/chriswood/pharmacy-first-clinical-pathway-conditions/7ec97762/",
       "downloaded_at": "2024-08-22 12:53:00.167017Z",
       "sha": "bed7f74add5c2d2ac6f7120d89f5ba94e57a28cb"
+    },
+    "opensafely-ethnicity-snomed-0removed.csv": {
+      "id": "opensafely/ethnicity-snomed-0removed/2e641f61",
+      "url": "https://www.opencodelists.org/codelist/opensafely/ethnicity-snomed-0removed/2e641f61/",
+      "downloaded_at": "2024-10-03 11:34:59.878387Z",
+      "sha": "8b849b5b785d80306e488d0109640c8c1d2da01b"
     }
   }
 }

--- a/codelists/codelists.txt
+++ b/codelists/codelists.txt
@@ -1,1 +1,2 @@
 user/chriswood/pharmacy-first-clinical-pathway-conditions/7ec97762
+opensafely/ethnicity-snomed-0removed/2e641f61

--- a/codelists/opensafely-ethnicity-snomed-0removed.csv
+++ b/codelists/opensafely-ethnicity-snomed-0removed.csv
@@ -1,0 +1,600 @@
+snomedcode,Ethnicity,Grouping_16,Grouping_6
+10292001,Guamians,16,5
+108342005,South Asian AND/OR Australian aborigine,16,5
+113170005,Aymara,16,5
+113171009,Coushatta,16,5
+13233008,Flathead,16,5
+154182006,Other ethnic non-mixed (NMO),16,5
+154183001,Brit. ethnic minor. spec.(NMO),16,5
+154184007,Brit. ethnic minor. unsp (NMO),16,5
+154186009,N African Arab &/or Iranian (NMO),16,5
+154195001,Other ethnic NEC (NMO),16,5
+154203007,Vietnamese,16,5
+154209006,Other ethnic group,16,5
+154212009,New Zealand ethnic groups,16,5
+154215006,New Zealand Maori,16,5
+154216007,Samoan,16,5
+154217003,Cook Island Maori,16,5
+154218008,Tongan,16,5
+154219000,Niuean,16,5
+154220006,Tokelauan,16,5
+154221005,Fijian,16,5
+154222003,Other Pacific ethnic group,16,5
+154227009,Other New Zealand ethnic group,16,5
+154229007,New Zealand ethnic group NOS,16,5
+15801006,Kapingas,16,5
+17789004,Papuans,16,5
+18575005,Oceanian,16,5
+186005001,Other ethnic non-mixed (NMO),16,5
+186006000,British ethnic minority specified (NMO),16,5
+186007009,British ethnic minority unspecified (NMO),16,5
+186009007,N African Arab &/or Iranian (NMO),16,5
+186018009,Other ethnic NEC (NMO),16,5
+186026001,Vietnamese,16,5
+186032006,Other ethnic group,16,5
+186035008,New Zealand ethnic groups,16,5
+186037000,Other European in New Zealand,16,5
+186039002,New Zealand Maori,16,5
+186040000,Cook Island Maori,16,5
+186041001,Niuean,16,5
+186042008,Tokelauan,16,5
+186043003,Other Pacific ethnic group,16,5
+186047002,Other New Zealand ethnic group,16,5
+186048007,New Zealand ethnic group NOS,16,5
+18664001,Xavante,16,5
+19085009,Saipanese,16,5
+20140003,Hawaiians,16,5
+20291009,Lacandon,16,5
+21047009,Aleuts,16,5
+22007004,Shoshone,16,5
+23517005,Polynesians,16,5
+23534002,Melanesians,16,5
+25750005,Admiralty Islanders,16,5
+270464009,N African Arab/Iranian (NMO),16,5
+27301002,Paez,16,5
+275594002,North African Arab (NMO),16,5
+275595001,Iranian (NMO),16,5
+27700004,Iraqi,16,5
+28821007,Easter Islanders,16,5
+296841000000102,Yemeni,16,5
+312859007,Vietnamese,16,5
+315282008,Other ethnic group,16,5
+32873005,Bloods,16,5
+33182009,Trukese,16,5
+3353005,Pueblo,16,5
+34334001,New Caledonians,16,5
+35007000,Utes,16,5
+3698008,Micronesians,16,5
+38144004,Athabascans,16,5
+38361009,Koreans,16,5
+38750003,Bororo,16,5
+4073004,Palauans,16,5
+413569000,Arab,16,5
+414661004,Melanesian,16,5
+41798002,Caroline Islanders,16,5
+43056000,Cuna,16,5
+43608005,Australian Aborigines,16,5
+43890005,Dieguenos,16,5
+47327008,Mexican Indians,16,5
+48118002,Yapese,16,5
+48294008,Solomon Islanders,16,5
+48375000,Seminole,16,5
+49202008,Gilbertese,16,5
+50405005,Senoi,16,5
+55990000,Inca,16,5
+57539009,Navaho,16,5
+583481000000105,Other ethnic NEC (NMO),16,5
+592491000000104,Other New Zealand ethnic group,16,5
+592501000000105,New Zealand ethnic group NOS,16,5
+59487007,Syrians,16,5
+59597001,Marshallese,16,5
+60157000,Ellice Islanders,16,5
+62598008,Venezuelan Indians,16,5
+63457007,Maya,16,5
+6373008,Choco,16,5
+63732001,New Hebrideans,16,5
+65776006,Blackfeet,16,5
+661731000000107,Other Pacific ethnic group,16,5
+66406004,Huasteco,16,5
+666871000000107,Other ethnic group,16,5
+66920001,Amerind,16,5
+67931002,Aztec,16,5
+69865008,Fijian,16,5
+69983001,Irani,16,5
+71949006,Chippewa,16,5
+72337002,Brazilian Indians,16,5
+73524008,Caingang,16,5
+73736004,Maori,16,5
+74159009,Melanuans,16,5
+74302004,Apache,16,5
+75301003,Mapuche,16,5
+75326007,Labradors,16,5
+75704009,Toba,16,5
+76460008,Yanomama,16,5
+76883002,Huichol,16,5
+77502007,Atacamenos,16,5
+77686000,Kwakiutl,16,5
+79434006,Quechua,16,5
+81560001,Tongan,16,5
+81653003,Pehuenches,16,5
+85515006,Eskimo,16,5
+86275006,Samoan,16,5
+87323008,Nez Percé,16,5
+89001000000105,Arab - ethnic category 2001 census,16,5
+89011000000107,Iranian - ethnic category 2001 census,16,5
+89021000000101,South and Central American - ethnic category 2001 census,16,5
+89026003,Alacaluf,16,5
+90027003,Arabs,16,5
+91488008,New Britons,16,5
+92521000000101,Other - ethnic category 2001 census,16,5
+94071000000100,"Middle Eastern (excluding Israeli, Iranian and Arab) - ethnic category 2001 census",16,5
+94081000000103,Israeli - ethnic category 2001 census,16,5
+94091000000101,Kurdish - ethnic category 2001 census,16,5
+94101000000109,Moroccan - ethnic category 2001 census,16,5
+94111000000106,Latin American - ethnic category 2001 census,16,5
+94121000000100,Multi-ethnic islands: Mauritian or Seychellois or Maldivian or St Helena - ethnic category 2001 census,16,5
+94151000000105,Any other group - ethnic category 2001 census,16,5
+976951000000102,Other ethnic group: Arab - England and Wales ethnic category 2011 census,16,5
+976961000000104,Other ethnic group: Arab - England and Wales ethnic category 2011 census,16,5
+976971000000106,Other ethnic group: any other ethnic group - England and Wales ethnic category 2011 census,16,5
+976981000000108,Other ethnic group: any other ethnic group - England and Wales ethnic category 2011 census,16,5
+977851000000109,Other ethnic group: Arab - Northern Ireland ethnic category 2011 census,16,5
+977861000000107,Other ethnic group: Arab - Northern Ireland ethnic category 2011 census,16,5
+977871000000100,Other ethnic group: any other ethnic group - Northern Ireland ethnic category 2011 census,16,5
+977881000000103,Other ethnic group: any other ethnic group - Northern Ireland ethnic category 2011 census,16,5
+978381000000105,"Other ethnic group: Arab, Arab Scottish or Arab British - Scotland ethnic category 2011 census",16,5
+978391000000107,"Other ethnic group: Arab, Arab Scottish or Arab British - Scotland ethnic category 2011 census",16,5
+978401000000105,Other ethnic group: any other ethnic group - Scotland ethnic category 2011 census,16,5
+978411000000107,Other ethnic group: any other ethnic group - Scotland ethnic category 2011 census,16,5
+154181004,Chinese,15,5
+154224002,Chinese,15,5
+186004002,Chinese,15,5
+33897005,Chinese,15,5
+92511000000107,Chinese - ethnic category 2001 census,15,5
+976851000000107,Asian or Asian British: Chinese - England and Wales ethnic category 2011 census,15,5
+977751000000101,Asian or Asian British: Chinese - Northern Ireland ethnic category 2011 census,15,5
+978191000000109,Asian or Asian Scottish or Asian British: Chinese - Scotland ethnic category 2011 census,15,5
+976861000000105,Asian or Asian British: Chinese - England and Wales ethnic category 2011 census,15,5
+977761000000103,Asian or Asian British: Chinese - Northern Ireland ethnic category 2011 census,15,5
+978201000000106,Asian or Asian Scottish or Asian British: Chinese - Scotland ethnic category 2011 census,15,5
+110791000000100,Black British - ethnic category 2001 census,14,4
+15086000,African American,14,4
+154166005,"Black, other, non-mixed origin",14,4
+154167001,Black British,14,4
+154169003,Black N African &/or Arab &/or Iranian,14,4
+154171003,Black E Afric Asia &/or Indo-Caribb,14,4
+154172005,Black Indian sub-continent,14,4
+154173000,Black - other Asian,14,4
+154174006,Black Black - other,14,4
+154206004,Other black ethnic group,14,4
+185989004,"Black, other, non-mixed origin",14,4
+185990008,Black British,14,4
+185992000,Black N African &/or Arab &/or Iranian,14,4
+185994004,Black E Afric Asia &/or Indo-Caribb,14,4
+185995003,Black Indian sub-continent,14,4
+185996002,Black - other Asian,14,4
+185997006,Black Black - other,14,4
+186029008,Other black ethnic group,14,4
+270461001,Black N African/Arab/Iranian,14,4
+270462008,Black East African Asian/Indo-Caribbean,14,4
+275587000,Black Arab,14,4
+275588005,Black Iranian,14,4
+275589002,Black East African Asian,14,4
+275590006,Black Indo-Caribbean,14,4
+315240009,Black - ethnic group,14,4
+315279003,Other black ethnic group,14,4
+651601000000100,Black Black - other,14,4
+92501000000105,Other Black background - ethnic category 2001 census,14,4
+92741000000104,Other Black or Black unspecified - ethnic category 2001 census,14,4
+976931000000109,Black or African or Caribbean or Black British: other Black or African or Caribbean background - England and Wales ethnic category 2011 census,14,4
+977831000000102,Black or African or Caribbean or Black British: other Black or African or Caribbean background - Northern Ireland ethnic category 2011 census,14,4
+978271000000103,"Caribbean or Black: Caribbean, Caribbean Scottish or Caribbean British - Scotland ethnic category 2011 census",14,4
+978341000000102,"Caribbean or Black: Black, Black Scottish or Black British - Scotland ethnic category 2011 census",14,4
+978361000000101,Caribbean or Black: any other Black or Caribbean group - Scotland ethnic category 2011 census,14,4
+976941000000100,Black or African or Caribbean or Black British : other black or African or Caribbean background - England and Wales ethnic category 2011 census,14,4
+978371000000108,Caribbean or Black: any other Black or Caribbean group - Scotland ethnic category 2011 census,14,4
+977841000000106,Black or African or Caribbean or Black British: other black or African or Caribbean background - Northern Ireland ethnic category 2011 census,14,4
+978351000000104,Caribbean or Black: Black Black Scottish or Black British - Scotland ethnic category 2011 census,14,4
+521000220104,Black Irish (ethnic group),14,4
+10008004,Ewe,13,4
+11794009,Kenyans,13,4
+13440006,Tanganyikans,13,4
+14470009,Tutsi,13,4
+154165009,Black African,13,4
+154170002,Black - other African country,13,4
+154187000,Other African countries (NMO),13,4
+18167009,Black African,13,4
+185993005,Black - other African country,13,4
+186010002,Other African countries (NMO),13,4
+1919006,Egyptians,13,4
+21868006,Madagascans,13,4
+23922002,Batutsi,13,4
+2720008,Hututu,13,4
+275586009,Black North African,13,4
+37474002,Ghanaians,13,4
+37843006,Fulani,13,4
+3818007,Senegalese,13,4
+39764005,Bantu,13,4
+41076003,Mozambiquans,13,4
+46110004,Somalis,13,4
+51750002,Hottentot,13,4
+52075006,Congolese,13,4
+58047002,Barundi,13,4
+59366001,Ibo,13,4
+67439005,Msutu,13,4
+71176007,Pygmies,13,4
+72201005,Hobe,13,4
+72248007,Kikuyu,13,4
+76253004,Zulu,13,4
+76775001,Ugandans,13,4
+80528001,Xosa,13,4
+8124001,West Africans,13,4
+82174001,Shona,13,4
+83584002,Luo,13,4
+85371009,Bushmen,13,4
+870448005,Khoikhoi,13,4
+88790004,Abyssinians (Amharas),13,4
+88839008,Sudanese,13,4
+88934004,Nigerians,13,4
+90822005,Gambians,13,4
+9158000,Liberians,13,4
+92491000000104,African - ethnic category 2001 census,13,4
+92711000000100,Somali - ethnic category 2001 census,13,4
+92731000000108,Nigerian - ethnic category 2001 census,13,4
+94061000000107,North African - ethnic category 2001 census,13,4
+976891000000104,Black or African or Caribbean or Black British: African - England and Wales ethnic category 2011 census,13,4
+977791000000109,Black or African or Caribbean or Black British: African - Northern Ireland ethnic category 2011 census,13,4
+978231000000100,"African: African, African Scottish or African British - Scotland ethnic category 2011 census",13,4
+978251000000107,African: any other African - Scotland ethnic category 2011 census,13,4
+978241000000109,African: African African Scottish or African British - Scotland ethnic category 2011 census,13,4
+976901000000103,Black or African or Caribbean or Black British: African - England and Wales ethnic category 2011 census,13,4
+977801000000108,Black or African or Caribbean or Black British: African - Northern Ireland ethnic category 2011 census,13,4
+978261000000105,African: any other African - Scotland ethnic category 2011 census,13,4
+107691000000105,Caribbean - ethnic category 2001 census,12,4
+154164008,Black Caribbean,12,4
+154168006,Black Caribbean &/or W.I. &/or Guyana,12,4
+154185008,Caribbean I. &/or W.I. &/or Guyana (NMO),12,4
+160531006,Race: West indian,12,4
+185988007,Black Caribbean,12,4
+185991007,Black Caribbean &/or W.I. &/or Guyana,12,4
+186008004,Caribbean I. &/or W.I. &/or Guyana (NMO),12,4
+270460000,Black Caribbean/West India/Guyana,12,4
+270463003,Caribbean I./W.I./Guyana (NMO),12,4
+275591005,Caribbean Island (NMO),12,4
+275592003,West Indian (NMO),12,4
+275593008,Guyana (NMO),12,4
+309643000,Black West Indian,12,4
+309644006,Black Guyana,12,4
+413465009,Afro-Caribbean,12,4
+976911000000101,Black or African or Caribbean or Black British: Caribbean - England and Wales ethnic category 2011 census,12,4
+977811000000105,Black or African or Caribbean or Black British: Caribbean - Northern Ireland ethnic category 2011 census,12,4
+976921000000107,Black or African or Caribbean or Black British : Caribbean - England and Wales ethnic category 2011 census (finding),12,4
+977821000000104,Black or African or Caribbean or Black British: Caribbean - Northern Ireland ethnic category 2011 census,12,4
+978281000000101,Caribbean or Black: Caribbean Caribbean Scottish or Caribbean British - Scotland ethnic category 2011 census,12,4
+10432001,Onge,11,3
+110781000000102,Sinhalese - ethnic category 2001 census,11,3
+12556008,Tamils,11,3
+1340002,Malays,11,3
+154188005,E Afric Asian &/or Indo-Carib (NMO),11,3
+154190006,Other Asian (NMO),11,3
+154207008,Other Asian ethnic group,11,3
+154223008,South East Asian,11,3
+154226000,Other Asian,11,3
+186011003,E Afric Asian &/or Indo-Carib (NMO),11,3
+186013000,Other Asian (NMO),11,3
+186030003,Other Asian ethnic group,11,3
+186044009,South East Asian,11,3
+186046006,Other Asian,11,3
+20449009,Javanese,11,3
+21993009,Indonesians,11,3
+24812003,Mongol,11,3
+26215007,South Asian Aborigine,11,3
+2688009,Tristan da Cunhans,11,3
+270465005,E Afric Asian/Indo-Carib (NMO),11,3
+275596000,East African Asian (NMO),11,3
+275597009,Indo-Caribbean (NMO),11,3
+27683006,Ainu,11,3
+2852001,Bhutanese,11,3
+28796001,Siamese,11,3
+315280000,Asian - ethnic group,11,3
+315281001,Other Asian ethnic group,11,3
+32513008,Dyaks,11,3
+40165009,Buriats,11,3
+414551003,Japanese,11,3
+414978006,Oriental,11,3
+42632009,Andamanese,11,3
+4299001,Marathas,11,3
+44460002,Turks,11,3
+46723002,Badagas,11,3
+47250000,Bruneians,11,3
+48679001,Bogobos,11,3
+53195006,Kirghiz,11,3
+57405008,Chenchu,11,3
+63736003,Taiwanese,11,3
+661741000000103,Other Asian,11,3
+67165000,Lapps,11,3
+704385002,Punjabi,11,3
+704386001,Orang asli,11,3
+704387005,Kadazan,11,3
+704388000,Melanau,11,3
+704389008,Murut,11,3
+704390004,Bajau,11,3
+704391000,Bidayuh,11,3
+704392007,Iban,11,3
+718131000000106,Nepali,11,3
+76768002,Filipinos,11,3
+81283004,Todas,11,3
+81846005,Naiars,11,3
+83365001,Thais,11,3
+83939006,Irula,11,3
+86461000000107,Sri Lankan - ethnic category 2001 census,11,3
+90348007,Ghashgai,11,3
+91066000,Tatars,11,3
+91191002,Oraons,11,3
+92481000000101,Other Asian background - ethnic category 2001 census,11,3
+92651000000105,Kashmiri - ethnic category 2001 census,11,3
+92661000000108,East African Asian - ethnic category 2001 census,11,3
+92671000000101,Tamil - ethnic category 2001 census,11,3
+92681000000104,British Asian - ethnic category 2001 census,11,3
+92691000000102,Caribbean Asian - ethnic category 2001 census,11,3
+92701000000102,Other Asian or Asian unspecified - ethnic category 2001 census,11,3
+92751000000101,Vietnamese - ethnic category 2001 census,11,3
+92761000000103,Japanese - ethnic category 2001 census,11,3
+92771000000105,Filipino - ethnic category 2001 census,11,3
+92781000000107,Malaysian - ethnic category 2001 census,11,3
+976871000000103,Asian or Asian British: any other Asian background - England and Wales ethnic category 2011 census,11,3
+977771000000105,Asian or Asian British: any other Asian background - Northern Ireland ethnic category 2011 census,11,3
+978211000000108,Asian or Asian Scottish or Asian British: any other Asian group - Scotland ethnic category 2011 census,11,3
+976881000000101,Asian or Asian British: any other Asian background - England and Wales ethnic category 2011 census,11,3
+977781000000107,Asian or Asian British: any other Asian background - Northern Ireland ethnic category 2011 census,11,3
+978221000000102,Asian or Asian Scottish or Asian British: any other Asian group - Scotland ethnic category 2011 census,11,3
+154180003,Bangladeshi,10,3
+186003008,Bangladeshi,10,3
+92471000000103,Bangladeshi or British Bangladeshi - ethnic category 2001 census,10,3
+976831000000100,Asian or Asian British: Bangladeshi - England and Wales ethnic category 2011 census,10,3
+977731000000108,Asian or Asian British: Bangladeshi - Northern Ireland ethnic category 2011 census,10,3
+978171000000105,"Asian or Asian Scottish or Asian British: Bangladeshi, Bangladeshi Scottish or Bangladeshi British - Scotland ethnic category 2011 census",10,3
+976841000000109,Asian or Asian British: Bangladeshi - England and Wales ethnic category 2011 census,10,3
+977741000000104,Asian or Asian British: Bangladeshi - Northern Ireland ethnic category 2011 census,10,3
+978181000000107,Asian or Asian Scottish or Asian British: Bangladeshi Bangladeshi Scottish or Banagaldeshi British - Scotland ethnic category 2011 census,10,3
+154179001,Pakistani,9,3
+186002003,Pakistani,9,3
+81035008,Pakistani (Urduspeakers),9,3
+92461000000105,Pakistani or British Pakistani - ethnic category 2001 census,9,3
+976811000000108,Asian or Asian British: Pakistani - England and Wales ethnic category 2011 census,9,3
+977711000000100,Asian or Asian British: Pakistani - Northern Ireland ethnic category 2011 census,9,3
+978071000000106,"Asian or Asian Scottish or Asian British: Pakistani, Pakistani Scottish or Pakistani British - Scotland ethnic category 2011 census",9,3
+978081000000108,Asian or Asian Scottish or Asian British: Pakistani Pakistani Scottish or Pakistani British - Scotland ethnic category 2011 census,9,3
+976821000000102,Asian or Asian British: Pakistani - England and Wales ethnic category 2011 census,9,3
+977721000000106,Asian or Asian British: Pakistani - Northern Ireland ethnic category 2011 census,9,3
+110751000000108,Indian or British Indian - ethnic category 2001 census,8,3
+154178009,Indian,8,3
+154189002,Indian sub-continent (NMO),8,3
+154225001,Indian,8,3
+186001005,Indian (East Indian),8,3
+186012005,Indian sub-continent (NMO),8,3
+186045005,Indian,8,3
+64483007,Indians (Hindi-speaking),8,3
+92641000000107,Punjabi - ethnic category 2001 census,8,3
+976791000000107,Asian or Asian British: Indian - England and Wales ethnic category 2011 census,8,3
+977591000000103,Asian or Asian British: Indian - Northern Ireland ethnic category 2011 census,8,3
+978111000000100,"Asian or Asian Scottish or Asian British: Indian, Indian Scottish or Indian British - Scotland ethnic category 2011 census",8,3
+977601000000109,Asian or Asian British: Indian - Northern Ireland ethnic category 2011 census,8,3
+976801000000106,Asian or Asian British: Indian - England and Wales ethnic category 2011 census,8,3
+978121000000106,Asian or Asian Scottish or Asian British: Indian Indian Scottish or Indian British - Scotland ethnic category 2011 census,8,3
+414481008,Indian (racial group),8,3
+110771000000104,Black and White - ethnic category 2001 census,7,2
+154175007,"Black - other, mixed",7,2
+154176008,Other Black - Black/White orig,7,2
+154177004,Other Black - Black/Asian orig,7,2
+154196000,"Other ethnic, mixed origin",7,2
+154197009,"Other ethnic, Black/White orig",7,2
+154199007,"Other ethnic, mixed white orig",7,2
+154200005,"Other ethnic, other mixed orig",7,2
+185998001,"Black - other, mixed",7,2
+185999009,Other Black - Black/White orig,7,2
+186000006,Other Black - Black/Asian orig,7,2
+186019001,"Other ethnic, mixed origin",7,2
+186022004,"Other ethnic, mixed white origin",7,2
+186023009,"Other ethnic, other mixed origin",7,2
+315239007,Mixed ethnic census group,7,2
+92451000000107,Other Mixed background - ethnic category 2001 census,7,2
+92581000000100,Black and Asian - ethnic category 2001 census,7,2
+92591000000103,Black and Chinese - ethnic category 2001 census,7,2
+92601000000109,Chinese and White - ethnic category 2001 census,7,2
+92611000000106,Asian and Chinese - ethnic category 2001 census,7,2
+92621000000100,Other Mixed or Mixed unspecified - ethnic category 2001 census,7,2
+92631000000103,Mixed Asian - ethnic category 2001 census,7,2
+92721000000106,Mixed Black - ethnic category 2001 census,7,2
+976771000000108,Mixed multiple ethnic groups: any other Mixed or multiple ethnic background - England and Wales ethnic category 2011 census,7,2
+976781000000105,Mixed multiple ethnic groups: any other Mixed or  Multiple ethnic background - England and Wales ethnic category 2011 census,7,2
+977551000000106,Mixed multiple ethnic groups: any other Mixed or multiple ethnic background - Northern Ireland ethnic category 2011 census,7,2
+977561000000109,Mixed multiple ethnic groups: any other Mixed or Multiple ethnic background - Northern Ireland ethnic category 2011 census,7,2
+978051000000102,Mixed or multiple ethnic groups: any Mixed or multiple ethnic group - Scotland ethnic category 2011 census,7,2
+978061000000104,Mixed or multiple ethnic groups: any Mixed or Multiple ethnic group - Scotland ethnic category 2011 census,7,2
+414752008,Mixed racial group (racial group),7,2
+154198004,"Other ethnic, Asian/White orig",6,2
+186021006,"Other ethnic, Asian/White origin",6,2
+92441000000109,White and Asian - ethnic category 2001 census,6,2
+976751000000104,Mixed multiple ethnic groups: White and Asian - England and Wales ethnic category 2011 census,6,2
+976761000000101,Mixed multiple ethnic groups: white and Asian - England and Wales ethnic category 2011 census,6,2
+977431000000100,Mixed multiple ethnic groups: White and Asian - Northern Ireland ethnic category 2011 census,6,2
+977441000000109,Mixed multiple ethnic groups: white and Asian - Northern Ireland ethnic category 2011 census,6,2
+154202002,Black African and White,5,2
+186025002,Black African and White,5,2
+315635008,Black African and White,5,2
+413466005,Afro-Caucasian,5,2
+92431000000100,White and Black African - ethnic category 2001 census,5,2
+976731000000106,Mixed multiple ethnic groups: White and Black African - England and Wales ethnic category 2011 census,5,2
+976741000000102,Mixed multiple ethnic groups: white and black African - England and Wales ethnic category 2011 census,5,2
+977411000000108,Mixed multiple ethnic groups: White and Black African - Northern Ireland ethnic category 2011 census,5,2
+977421000000102,Mixed multiple ethnic groups: white and black African - Northern Ireland ethnic category 2011 census,5,2
+154201009,Black Caribbean and White,4,2
+186020007,"Other ethnic, Black/White origin",4,2
+186024003,Black Caribbean and White,4,2
+315634007,Black Caribbean and White,4,2
+92421000000102,White and Black Caribbean - ethnic category 2001 census,4,2
+976711000000103,Mixed multiple ethnic groups: White and Black Caribbean - England and Wales ethnic category 2011 census,4,2
+976721000000109,Mixed multiple ethnic groups: white and black Caribbean - England and Wales ethnic category 2011 census,4,2
+977391000000108,Mixed multiple ethnic groups: White and Black Caribbean - Northern Ireland ethnic category 2011 census,4,2
+977401000000106,Mixed multiple ethnic groups: white and black Caribbean - Northern Ireland ethnic category 2011 census,4,2
+10117001,Finns,3,1
+1036211000000103,Slovak Roma,3,1
+1036251000000104,Czech Roma,3,1
+1036281000000105,Hungarian Roma,3,1
+1036301000000106,Polish Roma,3,1
+1036321000000102,Romanian Roma,3,1
+1036341000000109,Roma,3,1
+1036361000000105,Bulgarian Roma,3,1
+110401000000103,Turkish - ethnic category 2001 census,3,1
+113169009,Armenians,3,1
+14045001,Caucasian,3,1
+14176005,Danes,3,1
+1451003,Greeks,3,1
+154163002,Other white ethnic group,3,1
+154192003,Greek &/or Greek Cypriot (NMO),3,1
+154193008,Turkish &/or Turkish Cypriot (NMO),3,1
+154194002,Other European (NMO),3,1
+154208003,Irish traveller,3,1
+154213004,New Zealand European,3,1
+154214005,Other European in New Zealand,3,1
+17095009,Norwegians,3,1
+18583004,Estonians,3,1
+185984009,White - ethnic group,3,1
+185987002,Other white ethnic group,3,1
+186015007,Greek &/or Greek Cypriot (NMO),3,1
+186016008,Turkish &/or Turkish Cypriot (NMO),3,1
+186017004,Other European (NMO),3,1
+186031004,Irish traveller,3,1
+186036009,New Zealand European,3,1
+19434008,French,3,1
+270466006,Greek/Greek Cypriot (NMO),3,1
+270467002,Turkish/Turkish Cypriot (NMO),3,1
+275599007,Greek (NMO),3,1
+275600005,Greek Cypriot (NMO),3,1
+275601009,Turkish (NMO),3,1
+275602002,Turkish Cypriot (NMO),3,1
+28409002,Spaniards,3,1
+28562006,Poles,3,1
+286009,Czech,3,1
+29343004,Bulgarian,3,1
+315238004,Other white ethnic group,3,1
+315283003,Irish traveller,3,1
+31637002,Italians,3,1
+32045009,Georgians,3,1
+36329002,Slovak,3,1
+367505005,Caucasian (living organism),3,1
+393199009,Gypsies,3,1
+394149000,Gypsies,3,1
+394635008,Gypsies,3,1
+40182006,Gypsies,3,1
+414152003,European,3,1
+445343003,Romanian,3,1
+45465003,Basques,3,1
+518701000000103,Romanian,3,1
+518721000000107,Bulgarian,3,1
+519681000000108,Czech,3,1
+53460002,Serbs,3,1
+56056003,Belgians,3,1
+64693008,Hungarian,3,1
+668681000000107,Other white ethnic group,3,1
+68486007,Austrians,3,1
+710011000000101,Slovak,3,1
+718021000000105,Portuguese,3,1
+718958002,Roma,3,1
+718959005,Czech Roma,3,1
+718960000,Romanian Roma,3,1
+718961001,Slovak Roma,3,1
+718962008,Bulgarian Roma,3,1
+718963003,Hungarian Roma,3,1
+718964009,Polish Roma,3,1
+72809004,Icelanders,3,1
+733078003,Ukrainian,3,1
+733446001,Canadian,3,1
+735001008,Scandinavian,3,1
+76574004,Swiss,3,1
+7695005,Germans,3,1
+80208004,Portuguese,3,1
+81403004,Swedes,3,1
+85163001,Russians,3,1
+88911000000101,Irish Traveller - ethnic category 2001 census,3,1
+88921000000107,Traveller - ethnic category 2001 census,3,1
+88931000000109,Gypsy/Romany - ethnic category 2001 census,3,1
+88941000000100,Polish - ethnic category 2001 census,3,1
+88951000000102,Baltic States (Estonian or Latvian or Lithuanian) - ethnic category 2001 census,3,1
+88961000000104,Commonwealth of (Russian) Independent States - ethnic category 2001 census,3,1
+88971000000106,Albanian - ethnic category 2001 census,3,1
+88981000000108,Serbian - ethnic category 2001 census,3,1
+92411000000108,Other White background - ethnic category 2001 census,3,1
+92791000000109,Cypriot (part not stated) - ethnic category 2001 census,3,1
+93921000000101,Ulster Scots - ethnic category 2001 census,3,1
+93931000000104,Greek - ethnic category 2001 census,3,1
+93941000000108,Greek Cypriot - ethnic category 2001 census,3,1
+93951000000106,Turkish Cypriot - ethnic category 2001 census,3,1
+93961000000109,Italian - ethnic category 2001 census,3,1
+93981000000100,Kosovan - ethnic category 2001 census,3,1
+93991000000103,Bosnian - ethnic category 2001 census,3,1
+94001000000108,Croatian - ethnic category 2001 census,3,1
+94011000000105,Other republics which made up the former Yugoslavia - ethnic category 2001 census,3,1
+94021000000104,Mixed Irish and other White - ethnic category 2001 census,3,1
+94031000000102,Other mixed White - ethnic category 2001 census,3,1
+94041000000106,Other White European or European unspecified or Mixed European - ethnic category 2001 census,3,1
+94051000000109,Other White or White unspecified - ethnic category 2001 census,3,1
+9533000,Dutch,3,1
+976671000000104,White: Gypsy or Irish Traveller - England and Wales ethnic category 2011 census,3,1
+976691000000100,White: any other White background - England and Wales ethnic category 2011 census,3,1
+977351000000100,White - Northern Ireland ethnic category 2011 census,3,1
+977371000000109,Irish Traveller - Northern Ireland ethnic category 2011 census,3,1
+977971000000108,White: Gypsy or Irish Traveller - Scotland ethnic category 2011 census,3,1
+978011000000101,White: Polish - Scotland ethnic category 2011 census,3,1
+978031000000109,White: any other White ethnic group - Scotland ethnic category 2011 census,3,1
+978041000000100,White: any other white ethnic group - Scotland ethnic category 2011 census,3,1
+978021000000107,White: Polish - Scotland ethnic category 2011 census,3,1
+413773004,Caucasian (racial group),3,1
+977381000000106,Irish Traveller - Northern Ireland ethnic category 2011 census,3,1
+976701000000100,White: any other white background - England and Wales ethnic category 2011 census,3,1
+977981000000105,White: Gypsy or Irish Traveller - Scotland ethnic category 2011 census,3,1
+976681000000102,White: Gypsy or Irish Traveller - England and Wales ethnic category 2011 census,3,1
+154162007,White Irish,2,1
+154191005,Irish (NMO),2,1
+185986006,White Irish,2,1
+186014006,Irish (NMO),2,1
+315237009,White Irish,2,1
+494161000000100,White Irish - ethnic category 2001 census,2,1
+92401000000106,Irish - ethnic category 2001 census,2,1
+976651000000108,White: Irish - England and Wales ethnic category 2011 census,2,1
+977951000000104,White: Irish - Scotland ethnic category 2011 census,2,1
+976661000000106,White: Irish - England and Wales ethnic category 2011 census,2,1
+494171000000107,White Irish - ethnic category 2001 census,2,1
+494181000000109,White Irish - ethnic category 2001 census,2,1
+977961000000101,White: Irish - Scotland ethnic category 2011 census,2,1
+110761000000106,English - ethnic category 2001 census,1,1
+14999008,Welsh,1,1
+154160004,White - ethnic group,1,1
+154161000,White British,1,1
+185985005,White British,1,1
+25804004,English,1,1
+315236000,White British,1,1
+401213008,White Scottish,1,1
+401214002,Other white British ethnic group,1,1
+41121000000107,Other white British ethnic group,1,1
+43481000000100,Other white British ethnic group,1,1
+44881000000100,White Scottish,1,1
+44891000000103,Other white British ethnic group,1,1
+494131000000105,White British - ethnic category 2001 census,1,1
+77711000000105,Other white British ethnic group,1,1
+82121000000108,Other white British ethnic group,1,1
+92391000000108,British or mixed British - ethnic category 2001 census,1,1
+92541000000108,Scottish - ethnic category 2001 census,1,1
+92551000000106,Welsh - ethnic category 2001 census,1,1
+92561000000109,Northern Irish - ethnic category 2001 census,1,1
+92571000000102,Cornish - ethnic category 2001 census,1,1
+976631000000101,White: English or Welsh or Scottish or Northern Irish or British - England and Wales ethnic category 2011 census,1,1
+977911000000103,White: Scottish - Scotland ethnic category 2011 census,1,1
+977931000000106,White: other British - Scotland ethnic category 2011 census,1,1
+977921000000109,White: Scottish - Scotland ethnic category 2011 census,1,1
+494151000000103,White British - ethnic category 2001 census,1,1
+976641000000105,White: English or Welsh or Scottish or Northern Irish or British - England and Wales ethnic category 2011 census,1,1
+977361000000102,White - Northern Ireland ethnic category 2011 census,1,1
+977941000000102,White: other British - Scotland ethnic category 2011 census,1,1
+494141000000101,White British - ethnic category 2001 census,1,1

--- a/reports/pharmacy_first_report.Rmd
+++ b/reports/pharmacy_first_report.Rmd
@@ -79,6 +79,17 @@ pf_clinical_condition_dict_by_region <- c(
   "count_uncomplicated_urinary_tract_infection_by_region" = "UTI"
 )
 
+# Define the custom labels for clinical conditions by ethnicity
+pf_clinical_condition_dict_by_ethnicity <- c(
+  "count_acute_otitis_media_by_ethnicity" = "Acute Otitis Media",
+  "count_herpes_zoster_by_ethnicity" = "Herpes Zoster",
+  "count_acute_sinusitis_by_ethnicity" = "Acute Sinusitis",
+  "count_impetigo_by_ethnicity" = "Impetigo",
+  "count_infected_insect_bite_by_ethnicity" = "Infected Insect Bite",
+  "count_acute_pharyngitis_by_ethnicity" = "Acute Pharyngitis",
+  "count_uncomplicated_urinary_tract_infection_by_ethnicity" = "UTI"
+)
+
 # Define the custom labels for clinical services
 pf_clinical_service_dict <- c(
   "count_blood_pressure_service" = "Blood Pressure Service",
@@ -117,6 +128,14 @@ pf_clinical_service_dict_by_region <- c(
   "count_contraception_service_by_region" = "Contraception Service",
   "count_consultation_service_by_region" = "Consultation Service",
   "count_pharmacy_first_service_by_region" = "Pharmacy First Service"
+)
+
+# Define the custom labels for clinical services by ethnicity
+pf_clinical_service_dict_by_ethnicity <- c(
+  "count_blood_pressure_service_by_ethnicity" = "Blood Pressure Service",
+  "count_contraception_service_by_ethnicity" = "Contraception Service",
+  "count_consultation_service_by_ethnicity" = "Consultation Service",
+  "count_pharmacy_first_service_by_ethnicity" = "Pharmacy First Service"
 )
 ```
 
@@ -207,6 +226,20 @@ plot_measures(df_measures,
 )
 ```
 
+### Clinical Services by Ethnicity
+
+```{r, message=FALSE, warning=FALSE}
+
+plot_measures(df_measures,
+  title = "Number of consultations for each clinical service by ethnicity per month",
+  measure_names = names(pf_clinical_service_dict_by_ethnicity),
+  custom_labels = pf_clinical_service_dict_by_ethnicity,
+  y_label = "Number of codes for consultations",
+  facet_var = "ethnicity",
+  rotate_x_labels = TRUE
+)
+```
+
 ## Clinical Pathways
 
 This section focuses on the Clinical Pathways element of the Pharmacy First service.  
@@ -277,6 +310,20 @@ plot_measures(df_measures,
   custom_labels = pf_clinical_condition_dict_by_region,
   y_label = "Number of codes for consultations",
   facet_var = "region",
+  rotate_x_labels = TRUE
+)
+```
+
+### Clinical Conditions by Ethnicity
+
+```{r, message=FALSE, warning=FALSE}
+
+plot_measures(df_measures,
+  title = "Number of consultations for each clinical condition by ethnicity per month",
+  measure_names = names(pf_clinical_condition_dict_by_ethnicity),
+  custom_labels = pf_clinical_condition_dict_by_ethnicity,
+  y_label = "Number of codes for consultations",
+  facet_var = "ethnicity",
   rotate_x_labels = TRUE
 )
 ```

--- a/reports/pharmacy_first_report.Rmd
+++ b/reports/pharmacy_first_report.Rmd
@@ -160,7 +160,7 @@ plot_measures(df_measures,
   measure_names = names(pf_clinical_service_dict_by_age),
   custom_labels = pf_clinical_service_dict_by_age,
   y_label = "Number of codes for consultations",
-  facet_var = "age_band",
+  facet_var = "age",
   rotate_x_labels = TRUE
 )
 ```
@@ -234,7 +234,7 @@ plot_measures(df_measures,
   measure_names = names(pf_clinical_condition_dict_by_age),
   custom_labels = pf_clinical_condition_dict_by_age,
   y_label = "Number of codes for consultations",
-  facet_var = "age_band",
+  facet_var = "age",
   rotate_x_labels = TRUE
 )
 ```


### PR DESCRIPTION
When looking at the numerators in pf_codes_conditions_measures.csv, they are all 0 - this is only happening after I implemented ethnicity. Any ideas why?