### PR TITLE
Add `released_output/*` path to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 .Rhistory
 .Rproj.user/
 reports/pharmacy_first_report.html
+/released_output/*


### PR DESCRIPTION
This allows us to develop the report locally without pushing the released output to GitHub.

We can now download released ouputs from https://jobs.opensafely.org and add it to the `released_output` folder.