### PR TITLE
Add descriptive stats data to graph and add meds validation graph

### DIFF
--- a/reports/pharmacy_first_report.Rmd
+++ b/reports/pharmacy_first_report.Rmd
@@ -38,8 +38,11 @@ if (Sys.getenv("OPENSAFELY_BACKEND") != "") {
 
 # Load validation data (NHS BSA)
 df_bsa_validation <- read_csv(here("lib", "validation", "data", "pf_consultation_validation_data.csv"))
+df_bsa_meds <- read_csv(here("lib", "validation", "data", "pf_medication_validation_data.csv"))
 
-df_descriptive_stats <- read_csv(here("output", "measures", "pf_descriptive_stats_measures.csv"))
+df_descriptive_stats <- read_csv(here("released_output", "measures", "pf_descriptive_stats_measures.csv"))
+df_pfmed <- read_csv(here("output", "measures", "pf_medications_measures.csv"))
+df_condition_provider <- read_csv(here("released_output", "measures", "pf_condition_provider_measures.csv"))
 
 # Define dictionaries with tidy names and mappings for measures
 pf_measures_name_dict <- list(
@@ -936,7 +939,6 @@ descriptive_stats_figure <- ggplot(df_descriptive_stats, aes(x = interval_start,
   ) +
   scale_y_continuous(
     labels = scales::percent,
-    limits = c(0, 1)
   ) +
   theme(
     axis.title.x = element_blank(),
@@ -944,6 +946,67 @@ descriptive_stats_figure <- ggplot(df_descriptive_stats, aes(x = interval_start,
   )
 
 descriptive_stats_figure
+```
+
+```{r, message=FALSE, warning=FALSE, echo = FALSE, fig.width=8}
+
+# Validation of pharmacy first medication counts figure
+# OS data - waiting on released output
+
+df_bsa_total_meds <- df_bsa_meds %>%
+  group_by(date) %>%
+    summarise(total_meds = sum(count) * 0.4,
+    .groups = 'drop') %>% 
+    mutate(source = "BSA") 
+
+df_pfmed_total <- df_pfmed %>%
+  rename(date = interval_start) %>%
+  group_by(date) %>% 
+  summarise(total_meds = sum(numerator),
+  .groups = 'drop') %>%
+  mutate(source = "OS")
+
+df_validation_med_counts <- bind_rows(df_pfmed_total, df_bsa_total_meds)
+
+fig_validation_med_counts <- ggplot(df_validation_med_counts, aes(x = date, y = total_meds)) +
+  geom_point() +
+  geom_line(size = 0.5) +
+  facet_wrap(~source, scales = "free_y") +
+  labs(
+    title = "Pharmacy First Medications by Month (NHS BSA vs OpenSAFELY Data)",
+    x = "Month", y = "Count"
+  ) +
+  theme(
+    plot.title = element_text(hjust = 0.5),
+    axis.title.x = element_blank()
+  ) +
+  scale_x_date(
+    labels = scales::label_date_short()
+  )
+
+fig_validation_med_counts
+```
+```{r, message=FALSE, warning=FALSE, echo = FALSE, fig.width=8}
+# Condition - Provider graph, not there yet - needs some work. 
+# Need to discuss this tomorrow, how to visualise this graph, with respect to IMD and PF Status
+
+# figure_gp_vs_pf <- ggplot(df_condition_provider, aes(x = interval_start, y = numerator, color = pf_status, group = measure)) +
+#   geom_point() +
+#   geom_line(size = 0.5) +
+#   facet_wrap(~imd, scales = "free_y") +
+#   labs(
+#     title = "Count of clinical events",
+#     x = "Month", y = "Count", color = "Pharmacy First Status"
+#   ) +
+#   theme(
+#     plot.title = element_text(hjust = 0.5)
+#   ) +
+#   scale_x_date(
+#     labels = scales::label_date_short()
+#   )
+
+# figure_gp_vs_pf
+
 ```
 
 # References

--- a/reports/pharmacy_first_report.Rmd
+++ b/reports/pharmacy_first_report.Rmd
@@ -957,14 +957,16 @@ df_bsa_total_meds <- df_bsa_meds %>%
   group_by(date) %>%
     summarise(total_meds = sum(count) * 0.4,
     .groups = 'drop') %>% 
-    mutate(source = "BSA") 
+    mutate(source = "BSA") %>%
+    filter(date <= "2024-07-01")
 
 df_pfmed_total <- df_pfmed %>%
   rename(date = interval_start) %>%
   group_by(date) %>% 
   summarise(total_meds = sum(numerator),
   .groups = 'drop') %>%
-  mutate(source = "OS")
+  mutate(source = "OS") %>%
+  filter(date >= "2024-02-01")
 
 df_validation_med_counts <- bind_rows(df_pfmed_total, df_bsa_total_meds)
 

--- a/reports/pharmacy_first_report.Rmd
+++ b/reports/pharmacy_first_report.Rmd
@@ -41,7 +41,7 @@ df_bsa_validation <- read_csv(here("lib", "validation", "data", "pf_consultation
 df_bsa_meds <- read_csv(here("lib", "validation", "data", "pf_medication_validation_data.csv"))
 
 df_descriptive_stats <- read_csv(here("released_output", "measures", "pf_descriptive_stats_measures.csv"))
-df_pfmed <- read_csv(here("output", "measures", "pf_medications_measures.csv"))
+df_pfmed <- read_csv(here("released_output", "measures", "pf_medications_measures.csv"))
 df_condition_provider <- read_csv(here("released_output", "measures", "pf_condition_provider_measures.csv"))
 
 # Define dictionaries with tidy names and mappings for measures

--- a/reports/pharmacy_first_report.Rmd
+++ b/reports/pharmacy_first_report.Rmd
@@ -987,25 +987,46 @@ fig_validation_med_counts <- ggplot(df_validation_med_counts, aes(x = date, y = 
 fig_validation_med_counts
 ```
 ```{r, message=FALSE, warning=FALSE, echo = FALSE, fig.width=8}
-# Condition - Provider graph, not there yet - needs some work. 
-# Need to discuss this tomorrow, how to visualise this graph, with respect to IMD and PF Status
+# GP vs PF provider graph 
 
-# figure_gp_vs_pf <- ggplot(df_condition_provider, aes(x = interval_start, y = numerator, color = pf_status, group = measure)) +
-#   geom_point() +
-#   geom_line(size = 0.5) +
-#   facet_wrap(~imd, scales = "free_y") +
-#   labs(
-#     title = "Count of clinical events",
-#     x = "Month", y = "Count", color = "Pharmacy First Status"
-#   ) +
-#   theme(
-#     plot.title = element_text(hjust = 0.5)
-#   ) +
-#   scale_x_date(
-#     labels = scales::label_date_short()
-#   )
+df_condition_provider_grouped <- df_condition_provider %>% 
+  group_by(measure, interval_start, pf_status) %>% 
+  summarise(count = sum(numerator),
+  .groups = 'drop') %>%
+  mutate(
+    measure = recode(measure,
+      "count_acute_sinusitis_total" = "Acute Sinusitis",
+      "count_infected_insect_bite_total" = "Infected Insect Bite",
+      "count_uncomplicated_urinary_tract_infection_total" = "Uncomplicated UTI",
+      "count_acute_otitis_media_total" = "Acute Otitis Media",
+      "count_acute_pharyngitis_total" = "Acute Pharyngitis",
+      "count_herpes_zoster_total" = "Herpes Zoster",
+      "count_impetigo_total" = "Impetigo",
+    ),
+    pf_status = case_when(
+      pf_status == TRUE ~ "PF",
+      pf_status == FALSE ~ "GP"
+    )
+  )
 
-# figure_gp_vs_pf
+figure_gp_vs_pf <- ggplot(df_condition_provider_grouped, aes(x = interval_start, y = count, color = pf_status)) +
+  geom_point() +
+  geom_line(size = 0.5) +
+  facet_wrap(~measure, scales = "free_y") +
+  labs(
+    title = "Count of clinical events",
+    x = "Month", y = "Count", color = "Provider:"
+  ) +
+  theme(
+    plot.title = element_text(hjust = 0.5),
+    legend.position = "bottom",
+    axis.title.x = element_blank()
+  ) +
+  scale_x_date(
+    labels = scales::label_date_short()
+  )
+
+figure_gp_vs_pf
 
 ```
 


### PR DESCRIPTION
Closes #73 
- Added a graph which compares the BSA med numbers with OS. Dates have been filtered to ensure BSA and OS med graphs have consistent timeframes/axes. 

Closes #69
- Added a graph to show % of PF consultations with linked pfmed, pfcondition, and pfmed_and_pfcondition.

Closes #75 
- Added a graph to show GP vs PF clinical events, since 2023-01. Dates might need filtering though. 