### PR TITLE
Viv3ckj/extend-validation-and-study-periods

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,19 +1,19 @@
-# measures_definition_pf_breakdown.py
+# measures_definition_pf_breakdown.py (01/11/2023 - 01/11/2024)
 start_date_measure_pf_breakdown = "2023-11-01"
-monthly_intervals_measure_pf_breakdown = 13
+monthly_intervals_measure_pf_breakdown = 12
 
-# measures_definition_pf_condition_provider.py
+# measures_definition_pf_condition_provider.py (01/01/2023 - 01/11/2024)
 start_date_measure_condition_provider = "2023-01-01"
-monthly_intervals_measure_condition_provider = 23
+monthly_intervals_measure_condition_provider = 22
 
-# measures_definition_pf_descriptive_stats.py
+# measures_definition_pf_descriptive_stats.py (01/02/2024 - 01/11/2024)
 start_date_measure_descriptive_stats = "2024-02-01"
-monthly_intervals_measure_descriptive_stats = 10
+monthly_intervals_measure_descriptive_stats = 9
 
-# measures_definition_pf_medications.py
+# measures_definition_pf_medications.py (01/11/2023 - 01/11/2024)
 start_date_measure_medications = "2023-11-01"
-monthly_intervals_measure_medications = 10
+monthly_intervals_measure_medications = 12
 
-# measures_definition_pf_consultation_pf_counts.py
+# measures_definition_pf_consultation_pf_counts.py (01/02/2024 - 01/11/2024)
 start_date_measure_med_counts = "2024-02-01"
-monthly_intervals_measure_med_counts = 7
+monthly_intervals_measure_med_counts = 9

--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,19 +1,19 @@
 # measures_definition_pf_breakdown.py
 start_date_measure_pf_breakdown = "2023-11-01"
-monthly_intervals_measure_pf_breakdown = 12
+monthly_intervals_measure_pf_breakdown = 13
 
 # measures_definition_pf_condition_provider.py
 start_date_measure_condition_provider = "2023-01-01"
-monthly_intervals_measure_condition_provider = 22
+monthly_intervals_measure_condition_provider = 23
 
 # measures_definition_pf_descriptive_stats.py
 start_date_measure_descriptive_stats = "2024-02-01"
-monthly_intervals_measure_descriptive_stats = 9
+monthly_intervals_measure_descriptive_stats = 10
 
 # measures_definition_pf_medications.py
 start_date_measure_medications = "2023-11-01"
-monthly_intervals_measure_medications = 9
+monthly_intervals_measure_medications = 10
 
 # measures_definition_pf_consultation_pf_counts.py
 start_date_measure_med_counts = "2024-02-01"
-monthly_intervals_measure_med_counts = 6
+monthly_intervals_measure_med_counts = 7

--- a/lib/validation/data/pf_consultation_validation_data.csv
+++ b/lib/validation/data/pf_consultation_validation_data.csv
@@ -69,3 +69,10 @@ date,consultation_type,count
 2024-08-01,shingles,5151
 2024-08-01,sinusitis,10970
 2024-08-01,uncomplicated_uti,53389
+2024-09-01,acute_otitis_media,15680
+2024-09-01,acute_sore_throat,49991
+2024-09-01,impetigo,8390
+2024-09-01,infected_insect_bites,25348
+2024-09-01,shingles,4867
+2024-09-01,sinusitis,15059
+2024-09-01,uncomplicated_uti,56235

--- a/lib/validation/data/pf_medication_validation_data.csv
+++ b/lib/validation/data/pf_medication_validation_data.csv
@@ -76,3 +76,13 @@ date,pharmacy_advanced_service,bnf_paragraph,count
 2024-09-01,Pharmacy First Clinical Pathways,Preparations for minor cuts and abrasions,1939
 2024-09-01,Pharmacy First Clinical Pathways,Tetracyclines,735
 2024-09-01,Pharmacy First Clinical Pathways,Urinary-tract infections,47327
+2024-10-01,Pharmacy First Clinical Pathways,Antibacterial preparations,4491
+2024-10-01,Pharmacy First Clinical Pathways,Drugs used in nasal allergy,7939
+2024-10-01,Pharmacy First Clinical Pathways,Herpesvirus infections,4458
+2024-10-01,Pharmacy First Clinical Pathways,Individually formulated preparations bought in,12
+2024-10-01,Pharmacy First Clinical Pathways,Macrolides,7949
+2024-10-01,Pharmacy First Clinical Pathways,Otitis externa,5888
+2024-10-01,Pharmacy First Clinical Pathways,Penicillins,65765
+2024-10-01,Pharmacy First Clinical Pathways,Preparations for minor cuts and abrasions,2349
+2024-10-01,Pharmacy First Clinical Pathways,Tetracyclines,1182
+2024-10-01,Pharmacy First Clinical Pathways,Urinary-tract infections,52648


### PR DESCRIPTION
The major change in this PR is the updating of the `get_nhsbsa_data` function.
When running the code in `get_pf_medication_validation_data.R`, I ran into a lexical error, which was a critical issue that prevented the code from proceeding when the API returned invalid responses. Therefore the script seemed to fail immediately whenever the server responded with anything other than valid JSON. By introducing retries, the script could recover from temporary issues like rate limiting or server overload. 

The validation datasets now include September (for consultation validation data), and October (for medication validation data). The study monthly intervals have all been increased by one month. 

Closes #92 