### PR TITLE
Add has_pf_consultation to define population

### DIFF
--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -89,3 +89,11 @@ pf_consultation_events_dict = {
     "pf_consultation_services_combined": pf_consultation_cp_minorillness
     + pf_consultation_service + pf_consultation_cp_service,
 }
+
+uti_code = ["1090711000000102"]
+sinusitis_code = ["15805002"]
+insectbite_code = ["262550002"]
+otitismedia_code = ["3110003"]
+sorethroat_code = ["363746003"]
+shingles_code = ["4740000"]
+impetigo_code = ["48277006"]

--- a/analysis/dataset_definition_table1.py
+++ b/analysis/dataset_definition_table1.py
@@ -1,4 +1,4 @@
-from ehrql import create_dataset, case, when
+from ehrql import create_dataset
 from ehrql.tables.tpp import (
     patients,
     clinical_events,
@@ -20,7 +20,7 @@ from pf_dataset import (
     get_age_band,
     get_imd
 )
-
+from pf_variables_library import select_events
 import codelists
 
 index_date = "2024-12-31"
@@ -64,22 +64,18 @@ dataset.otitismedia_denominator = get_acute_otitis_media_denominator(
 dataset.pregnancy_status = check_pregnancy_status(
     index_date, selected_events, codelists.pregnancy_codelist
 )
-uti_code = ["1090711000000102"]
-sinusitis_code = ["15805002"]
-insectbite_code = ["262550002"]
-otitismedia_code = ["3110003"]
-sorethroat_code = ["363746003"]
-shingles_code = ["4740000"]
-impetigo_code = ["48277006"]
 
-dataset.uti_numerator = get_numerator(selected_events, uti_code, dataset.uti_denominator)
-dataset.sinusitis_numerator = get_numerator(selected_events, sinusitis_code, dataset.sinusitis_denominator)
-dataset.insectbite_numerator = get_numerator(selected_events, insectbite_code, dataset.insectbite_denominator)
-dataset.otitismedia_numerator = get_numerator(selected_events, otitismedia_code, dataset.otitismedia_denominator)
-dataset.sorethroat_numerator = get_numerator(selected_events, sorethroat_code, dataset.sorethroat_denominator)
-dataset.shingles_numerator = get_numerator(selected_events, shingles_code, dataset.shingles_denominator)
-dataset.impetigo_numerator = get_numerator(selected_events, impetigo_code, dataset.impetigo_denominator)
+dataset.uti_numerator = get_numerator(selected_events, codelists.uti_code, dataset.uti_denominator)
+dataset.sinusitis_numerator = get_numerator(selected_events, codelists.sinusitis_code, dataset.sinusitis_denominator)
+dataset.insectbite_numerator = get_numerator(selected_events, codelists.insectbite_code, dataset.insectbite_denominator)
+dataset.otitismedia_numerator = get_numerator(selected_events, codelists.otitismedia_code, dataset.otitismedia_denominator)
+dataset.sorethroat_numerator = get_numerator(selected_events, codelists.sorethroat_code, dataset.sorethroat_denominator)
+dataset.shingles_numerator = get_numerator(selected_events, codelists.shingles_code, dataset.shingles_denominator)
+dataset.impetigo_numerator = get_numerator(selected_events, codelists.impetigo_code, dataset.impetigo_denominator)
+
+pf_consultation_events = select_events(selected_events, codelist=codelists.pf_consultation_events_dict["pf_consultation_services_combined"])
+has_pf_consultation = pf_consultation_events.exists_for_patient()
 
 dataset.define_population(
-    registration.exists_for_patient() & patients.sex.is_in(["male", "female"])
+    registration.exists_for_patient() & patients.sex.is_in(["male", "female"]) & has_pf_consultation
 )


### PR DESCRIPTION
Population for demographics table now uses `has_pf_consultation` as a constraint. Also moved condition codes out of `dataset_definition_table1.py` and into `codelists.py`

Closes #107 