### PR TITLE
Add additional descriptive stats and removed same_date stats

### DIFF
--- a/analysis/measures_definition_pf_descriptive_stats.py
+++ b/analysis/measures_definition_pf_descriptive_stats.py
@@ -15,7 +15,7 @@ from config import (
 
 measures = create_measures()
 measures.configure_dummy_data(population_size=100)
-measures.configure_disclosure_control(enabled=True)
+measures.configure_disclosure_control(enabled=False)
 
 start_date = start_date_measure_descriptive_stats
 monthly_intervals = monthly_intervals_measure_descriptive_stats
@@ -42,39 +42,42 @@ pf_consultation_events = select_events(
     codelist=pf_consultation_events_dict["pf_consultation_services_combined"],
 )
 
-# Extract Pharmacy First consultation IDs and dates
+# Extract Pharmacy First consultation IDs
 pf_ids = pf_consultation_events.consultation_id
-pf_dates = pf_consultation_events.date
-
 has_pf_consultation = pf_consultation_events.exists_for_patient()
+# Counts number of Pharmacy First consultations
+pf_consultation_count = pf_consultation_events.count_for_patient()
 
 # Select Pharmacy First conditions by ID and date
 selected_pf_id_conditions = selected_events.where(
     selected_events.consultation_id.is_in(pf_ids)
 ).where(selected_events.snomedct_code.is_in(pf_conditions_codelist))
 
-selected_pf_date_conditions = (
-    selected_events.where(selected_events.consultation_id.is_not_in(pf_ids))
-    .where(selected_events.date.is_in(pf_dates))
-    .where(selected_events.snomedct_code.is_in(pf_conditions_codelist))
+non_pf_condition_events = selected_events.except_where(
+    selected_events.snomedct_code.is_in(
+        pf_conditions_codelist
+    )).except_where(selected_events.snomedct_code.is_in(pf_consultation_events_dict["pf_consultation_services_combined"])
 )
 
 has_pf_id_condition = selected_pf_id_conditions.exists_for_patient()
-has_pf_date_condition = selected_pf_date_conditions.exists_for_patient()
+# Counts occurences of all Pharmacy First conditions per month
+pf_condition_count = selected_pf_id_conditions.count_for_patient()
+# Counts occurences of all non-Pharmacy First conditions from PF consultations per month
+nonpf_condition_count = non_pf_condition_events.where(non_pf_condition_events.consultation_id.is_in(pf_ids)).count_for_patient()
 
 # Select Pharmacy First Medications by ID and date
 selected_pf_id_medications = selected_medications.where(
     selected_medications.consultation_id.is_in(pf_ids)
 ).where(selected_medications.dmd_code.is_in(pf_med_codelist))
 
-selected_pf_date_medications = (
-    selected_medications.where(selected_medications.consultation_id.is_not_in(pf_ids))
-    .where(selected_medications.date.is_in(pf_dates))
-    .where(selected_medications.dmd_code.is_in(pf_med_codelist))
-)
+selected_nonpf_id_medications = selected_medications.where(
+    selected_medications.consultation_id.is_in(pf_ids)
+).except_where(selected_medications.dmd_code.is_in(pf_med_codelist))
+
 
 has_pf_id_medication = selected_pf_id_medications.exists_for_patient()
-has_pf_date_medication = selected_pf_date_medications.exists_for_patient()
+pf_med_count = selected_pf_id_medications.count_for_patient()
+nonpf_med_count = selected_nonpf_id_medications.count_for_patient()
 
 # Define measures
 measures.define_defaults(
@@ -102,18 +105,27 @@ measures.define_measure(
     numerator=has_pf_id_medication & has_pf_id_condition,
 )
 
-# Measures linked by Pharmacy First consultation date
 measures.define_measure(
-    name="pfmed_on_pfdate",
-    numerator=has_pf_date_medication,
+    name="pfconsultations_month_count",
+    numerator=pf_consultation_count,
 )
 
 measures.define_measure(
-    name="pfcondition_on_pfdate",
-    numerator=has_pf_date_condition,
+    name="pfconditions_month_count",
+    numerator=pf_condition_count,
 )
 
 measures.define_measure(
-    name="pfmed_and_pfcondition_on_pfdate",
-    numerator=has_pf_date_medication & has_pf_date_condition,
+    name="non_pfconditions_month_count",
+    numerator=nonpf_condition_count,
+)
+
+measures.define_measure(
+    name="pfmed_month_count",
+    numerator=pf_med_count,
+)
+
+measures.define_measure(
+    name="non_pfmed_month_count",
+    numerator = nonpf_med_count,
 )

--- a/analysis/measures_definition_pf_descriptive_stats.py
+++ b/analysis/measures_definition_pf_descriptive_stats.py
@@ -106,26 +106,26 @@ measures.define_measure(
 )
 
 measures.define_measure(
-    name="pfconsultations_month_count",
+    name="pfconsultations_count",
     numerator=pf_consultation_count,
 )
 
 measures.define_measure(
-    name="pfconditions_month_count",
+    name="pfconditions_count",
     numerator=pf_condition_count,
 )
 
 measures.define_measure(
-    name="non_pfconditions_month_count",
+    name="non_pfconditions_count",
     numerator=nonpf_condition_count,
 )
 
 measures.define_measure(
-    name="pfmed_month_count",
+    name="pfmed_count",
     numerator=pf_med_count,
 )
 
 measures.define_measure(
-    name="non_pfmed_month_count",
+    name="non_pfmed_count",
     numerator = nonpf_med_count,
 )

--- a/analysis/pf_dataset.py
+++ b/analysis/pf_dataset.py
@@ -21,7 +21,7 @@ def get_numerator(index_date, patients, pregnancy_codelist, selected_events, con
     inclusion_criteria = False
     exclusion_criteria = False
 
-    if clinical_pathway == "UTI":
+    if clinical_pathway == "uti":
         urt_code = ["1090711000000102"]
         count_urt_6m = count_past_events(index_date, selected_events, urt_code, 6)
         count_urt_12m = count_past_events(index_date, selected_events, urt_code, 12)


### PR DESCRIPTION
In this PR, I have done the following:

- Removed same_date and other unnecessary code (Closes #129)
- Added five new measures (Closes #101)
  - `pfconsultations_count` (counts all pf consultations in one month)
  - `pfconditions_count` (counts all pf conditions from pf consultations in one month)
  - `non_pfconditions_count` (counts all non pf conditions from pf consultations in one month)
  - `pfmed_count` (counts all pf meds from pf consultations in one month)
  - `non_pfmed_count` (counts all non pf meds from pf consultations in one month)

The denominator for all includes `has_pf_consultation`, which will be one consultation per patient, and not a count. Therefore by this logic, we can calculate how many times there were more than one consultation/condition/med per patient per month by subtracting numerator from denominator. 

I used the following dummy data to test this:

clinical_events.csv:
```
patient_id,consultation_id,date,snomedct_code
1,1,2024-03-01,1577041000000109
1,1,2024-03-01,15805002
1,1,2024-03-01,363746003
1,1,2024-03-04,1577041000000109
2,2,2024-03-01,1577041000000109
2,2,2024-03-01,100
3,3,2024-03-01,1577041000000109
3,3,2024-03-01,15805002
4,4,2024-03-01,1577041000000109
4,4,2024-03-07,1577041000000109
4,4,2024-03-01,15805002
4,4,2024-03-01,363746003
5,5,2024-03-01,100000
5,5,2024-03-01,15805002
```

medications_raw.csv:
```
patient_id,consultation_id,date,dmd_code
1,1,2024-03-01,10000000000000000
2,2,2024-03-01,39692111000001101
3,3,2023-12-01,10000000000000000
4,4,2024-03-01,39692111000001101
5,5,2023-12-01,10000000000000000
```

And generated the following data:
![image](https://github.com/user-attachments/assets/32018843-876f-40f3-bfb4-f7d5e0c998b9)


1. For `pfconsultations_count`, we see numerator = 6, because `1577041000000109` is a pharmacy first consultation code, and it appears 6 times. But only four patients have this code, so the denominator is 4. Subtracting the denominator from the numerator = 2, and so we can conclude that there have been 2 extra pharmacy first consultations. However, the flaw is that this does not tell us how many patients had more than one pharmacy first consultation, only how many times a patient had more than one pharmacy first consultation. 

2. For `pfconditions_count`, we have two pharmacy first condition codes (`15805002` & `363746003`). There are 5 occurences of a pharmacy first condition (excluding patient 5 - as its not a pf consultation). Again we can subtract denominator from numerator, where we see 1 extra condition. 

3. `non_pfconditions_count` is fairly self explanatory, but this time I think I got it to work as it should. Usually, when using `except_where()`, it will include every code that is not a pf condition, including pf consultation codes - which is not what we want to include. This is why I have added pf consultation codes as an additional except_where. 

4. `pfmed_count` and `non_pfmed_count` are counts of pf and non pf meds per consultation, and again we can subtract to get how many extra medication are being coded for. 

I'm not convinced this is the best way to do this, nor the right way to do it, but let me know what you think. 

