### PR TITLE
Address vmp_nm == NA error by using 'term' name instead.

### DIFF
--- a/reports/create_tables.Rmd
+++ b/reports/create_tables.Rmd
@@ -75,7 +75,11 @@ df_pf_med_counts <- df_consultation_med_counts |>
   select(numerator, code = dmd_code, pharmacy_first_med) |>
   left_join(combined_med_code_desc, by = "code") |>
   filter(numerator > 0) |>
-  select(-code) %>%
+  select(-code) %>% 
+  mutate(vmp_nm = case_when(
+    is.na(vmp_nm) ~ term, 
+    TRUE ~ vmp_nm
+   )) %>% 
   group_by(pharmacy_first_med, vmp_nm) |>
   summarise(count = sum(numerator, na.rm = TRUE)) |>
   filter(!is.na(vmp_nm)) %>%


### PR DESCRIPTION
Made a small fix where I found in the meds table some rows with vmp_nm == NA (which should contain the vmp term name), but they had a term name in a different column. So added a case_when to make it so that if vmp_nm == NA, use the term name from the 'term' column. This changed the %'s of table 3 slightly, as meds with NA names would previously have been removed from the dataset. 