### PR TITLE
Viv3ckj/update report apr

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -9,8 +9,8 @@ start_date_measure_condition_provider = "2023-01-01"
 monthly_intervals_measure_condition_provider = 25
 
 # Number of months included in the monthly dashboard - INCREASE THIS INTERVAL BY ONE EACH MONTH
-# Current timeframe of monthly dashboard: 01/11/2023 - 31/03/2026 (UPDATE this timeframe monthly)
-monthly_dashboard_intervals = 29
+# Current timeframe of monthly dashboard: 01/11/2023 - 30/04/2026 (UPDATE this timeframe monthly)
+monthly_dashboard_intervals = 30
 
 # Measure: measures_definition_pf_breakdown.py
 start_date_measure_pf_breakdown = "2023-11-01"

--- a/analysis/create_monthly_tables.R
+++ b/analysis/create_monthly_tables.R
@@ -1,16 +1,12 @@
 library(here)
 library(tidyverse)
 
-pf_consultations_with_breakdowns <- read_csv(here(
-  "output",
-  "measures",
-  "pf_breakdown_measures.csv"
-))
-pf_completeness <- read_csv(here(
-  "output",
-  "measures",
-  "pf_descriptive_stats_measures.csv"
-))
+pf_consultations_with_breakdowns <- read_csv(
+  here("output", "measures", "pf_breakdown_measures.csv")
+)
+pf_completeness <- read_csv(
+  here("output", "measures", "pf_descriptive_stats_measures.csv")
+)
 
 pf_consultations_with_breakdowns_clean <- pf_consultations_with_breakdowns %>%
   mutate(
@@ -50,7 +46,9 @@ pf_completeness_clean <- pf_completeness %>%
     measure == "pfmed_with_pfid" |
       measure == "pfcondition_with_pfid" |
       measure == "pfmed_and_pfcondition_with_pfid"
-  )
+  ) %>% select(-ratio, -denominator)
+
+dir.create(here("output", "user_tables"))
 
 readr::write_csv(
   pf_consultations_with_breakdowns_clean,

--- a/analysis/create_monthly_tables.R
+++ b/analysis/create_monthly_tables.R
@@ -33,7 +33,7 @@ pf_consultations_with_breakdowns_clean <- pf_consultations_with_breakdowns %>%
     interval_end,
     group_type,
     group,
-    value = numerator,
+    count = numerator,
   ) %>%
   arrange(interval_start, measure_type, measure, group_type, group) %>%
   filter(
@@ -46,7 +46,9 @@ pf_completeness_clean <- pf_completeness %>%
     measure == "pfmed_with_pfid" |
       measure == "pfcondition_with_pfid" |
       measure == "pfmed_and_pfcondition_with_pfid"
-  ) %>% select(-ratio, -denominator)
+  ) %>%
+  select(-ratio, -denominator) %>%
+  rename(count = numerator)
 
 dir.create(here("output", "user_tables"))
 

--- a/analysis/create_monthly_tables.R
+++ b/analysis/create_monthly_tables.R
@@ -1,0 +1,63 @@
+library(here)
+library(tidyverse)
+
+pf_consultations_with_breakdowns <- read_csv(here(
+  "output",
+  "measures",
+  "pf_breakdown_measures.csv"
+))
+pf_completeness <- read_csv(here(
+  "output",
+  "measures",
+  "pf_descriptive_stats_measures.csv"
+))
+
+pf_consultations_with_breakdowns_clean <- pf_consultations_with_breakdowns %>%
+  mutate(
+    group_type = case_when(
+      !is.na(age_band) ~ "Age band",
+      !is.na(sex) ~ "Sex",
+      !is.na(imd) ~ "IMD",
+      !is.na(region) ~ "Region",
+      !is.na(ethnicity) ~ "Ethnicity",
+      TRUE ~ "Overall"
+    ),
+    group = coalesce(age_band, sex, imd, region, ethnicity),
+    measure_type = case_when(
+      str_detect(measure, "consultation|service") ~ "clinical_service",
+      TRUE ~ "clinical_condition"
+    ),
+    measure = str_remove(measure, "^count_") %>%
+      str_remove("_by_.*$")
+  ) %>%
+  transmute(
+    measure_type,
+    measure,
+    interval_start,
+    interval_end,
+    group_type,
+    group,
+    value = numerator,
+  ) %>%
+  arrange(interval_start, measure_type, measure, group_type, group) %>%
+  filter(
+    !(measure_type == "clinical_condition" &
+      interval_start < as.Date("2024-02-01"))
+  )
+
+pf_completeness_clean <- pf_completeness %>%
+  filter(
+    measure == "pfmed_with_pfid" |
+      measure == "pfcondition_with_pfid" |
+      measure == "pfmed_and_pfcondition_with_pfid"
+  )
+
+readr::write_csv(
+  pf_consultations_with_breakdowns_clean,
+  here::here("output", "user_tables", "pf_consultations_with_breakdowns.csv")
+)
+
+readr::write_csv(
+  pf_completeness_clean,
+  here::here("output", "user_tables", "pf_completeness.csv")
+)

--- a/project.yaml
+++ b/project.yaml
@@ -119,7 +119,9 @@ actions:
   
   generate_pf_opensafely_monthly_report_tables: 
     run: r:v2 analysis/create_monthly_tables.R
-    needs: [generate_pf_opensafely_monthly_report]
+    needs:
+      - generate_pf_breakdown_measures
+      - generate_pf_statistics_measures
     outputs:
       moderately_sensitive:
         dataset: output/user_tables/pf_consultations_with_breakdowns.csv

--- a/project.yaml
+++ b/project.yaml
@@ -116,3 +116,11 @@ actions:
         pf_by_ethnicity: output/report/figures/figure6ethnicity_updated.png
         pf_completeness: output/report/figures/figure7_updated.png
         pf_clinical_conditions: output/report/figures/figure8clinicalpathways_updated.png
+  
+  generate_pf_opensafely_monthly_report_tables: 
+    run: r:v2 analysis/create_monthly_tables.R
+    needs: [generate_pf_opensafely_monthly_report]
+    outputs:
+      moderately_sensitive:
+        dataset: output/user_tables/pf_consultations_with_breakdowns.csv
+        dataset2: output/user_tables/pf_completeness.csv

--- a/reports/pharmacy_first_monthly_report.Rmd
+++ b/reports/pharmacy_first_monthly_report.Rmd
@@ -37,7 +37,7 @@ source(here("lib", "functions", "create_tables.R"))
 source(here("lib", "functions", "load_opensafely_outputs.R"))
 
 # Define report date
-report_date <- as.Date("2026-03-31")
+report_date <- as.Date("2026-04-30")
 ```
 
 This OpenSAFELY report presents real-time analyses of the Pharmacy First service using data from OpenSAFELY-TPP. 


### PR DESCRIPTION
## What are we trying to achieve?

We received a request via email asking whether the raw data behind the Pharmacy First monthly dashboard could also be made available for download alongside the report:
https://reports.opensafely.org/reports/opensafely-pharmacy-first-monthly-dashboard/

The aim is to make it easier for users to reuse and analyse the dashboard data themselves.

## What is the problem?

Although we could publish the current outputs directly (`pf_breakdown_measures.csv` and `pf_descriptive_stats_measures.csv`), these tables are analysis-oriented and difficult for external users to work with.

Current issues include:
- many mostly-empty (`NA`) columns
- grouping information embedded in measure names (e.g. `_by_sex`, `_by_imd`)
- internal variable names
- multiple stratifications combined into sparse wide tables
- columns that are not useful to dashboard users

For example:

| measure | age_band | sex | imd |
| --- | --- | --- | --- |
| count_impetigo_by_sex | NA | Female | NA |

This structure is difficult to filter/pivot and requires users to interpret metadata encoded inside the measure names.

## Proposed approach

This PR creates:
- a new script: `analysis/create_monthly_tables.R`
- a new action: `generate_pf_opensafely_monthly_report_tables`

These generate new user-facing downloadable tables from the existing analysis outputs.

The downloadable outputs would be:
- `pf_consultations_with_breakdowns.csv`
- `pf_completeness.csv`

These are new outputs and would sit alongside the existing outputs rather than replace them.

The cleaned tables:
- use a tidier structure (`measure_type`, `group_type`, `group`)
- remove unnecessary columns
- simplify measure names
- separate grouping metadata from measure names
- make the outputs easier to filter/pivot in Excel or downstream analysis

Example proposed structure:

| measure_type | measure | group_type | group | value |
| --- | --- | --- | --- | --- |
| clinical_condition | impetigo | Sex | Female | 123 |

## Alternatives considered

An alternative would be to publish the current analysis outputs directly.

However, this would make the downloads harder for external users to understand and work with, as the current tables are designed for report generation rather than public use.

Another option would be to create many separate CSVs for each stratification/figure, but this would increase maintenance burden and make the downloads harder to navigate.

The proposed approach keeps the number of downloadable files small while making the structure more user friendly.

Closes #205 

The downloadable breakdown and descriptive tables will now look like this:

<img width="1151" height="334" alt="image" src="https://github.com/user-attachments/assets/2f6dc6cd-5cf1-4654-9156-be61614d2504" />

<img width="672" height="119" alt="image" src="https://github.com/user-attachments/assets/7ffae61f-b002-4f3e-b481-44005007704d" />
