### PR TITLE
Split combined consultations csv into conditions and consultation csvs

### DIFF
--- a/analysis/create_monthly_tables.R
+++ b/analysis/create_monthly_tables.R
@@ -8,7 +8,7 @@ pf_completeness <- read_csv(
   here("output", "measures", "pf_descriptive_stats_measures.csv")
 )
 
-pf_consultations_with_breakdowns_clean <- pf_consultations_with_breakdowns %>%
+pf_consultations_clean <- pf_consultations_with_breakdowns %>%
   mutate(
     group_type = case_when(
       !is.na(age_band) ~ "Age band",
@@ -35,11 +35,7 @@ pf_consultations_with_breakdowns_clean <- pf_consultations_with_breakdowns %>%
     group,
     count = numerator,
   ) %>%
-  arrange(interval_start, measure_type, measure, group_type, group) %>%
-  filter(
-    !(measure_type == "clinical_condition" &
-      interval_start < as.Date("2024-02-01"))
-  )
+  arrange(interval_start, measure_type, measure, group_type, group)
 
 pf_completeness_clean <- pf_completeness %>%
   filter(
@@ -50,11 +46,25 @@ pf_completeness_clean <- pf_completeness %>%
   select(-ratio, -denominator) %>%
   rename(count = numerator)
 
+pf_consultations_only <- pf_consultations_clean %>%
+  filter(measure_type == "clinical_service")
+
+pf_conditions_only <- pf_consultations_clean %>%
+  filter(
+    measure_type == "clinical_condition",
+    interval_start >= as.Date("2024-02-01")
+  )
+
 dir.create(here("output", "user_tables"))
 
 readr::write_csv(
-  pf_consultations_with_breakdowns_clean,
+  pf_consultations_only,
   here::here("output", "user_tables", "pf_consultations_with_breakdowns.csv")
+)
+
+readr::write_csv(
+  pf_conditions_only,
+  here::here("output", "user_tables", "pf_conditions_with_breakdowns.csv")
 )
 
 readr::write_csv(

--- a/project.yaml
+++ b/project.yaml
@@ -125,4 +125,5 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/user_tables/pf_consultations_with_breakdowns.csv
+        dataset1: output/user_tables/pf_conditions_with_breakdowns.csv
         dataset2: output/user_tables/pf_completeness.csv


### PR DESCRIPTION
After running the job, we encountered an error saying that 'output/user_tables/pf_consultations_with_breakdowns.csv' contained 9270 rows, which is more than the limit of 5000. 

So we have split the CSV into conditions CSV and consultations CSV.