### PR TITLE
Viv3ckj/shorten conditions csv

### DIFF
--- a/analysis/create_monthly_tables.R
+++ b/analysis/create_monthly_tables.R
@@ -41,7 +41,8 @@ pf_completeness_clean <- pf_completeness %>%
   filter(
     measure == "pfmed_with_pfid" |
       measure == "pfcondition_with_pfid" |
-      measure == "pfmed_and_pfcondition_with_pfid"
+      measure == "pfmed_and_pfcondition_with_pfid",
+    interval_start >= as.Date("2024-02-01")
   ) %>%
   select(-ratio, -denominator) %>%
   rename(count = numerator)
@@ -52,8 +53,7 @@ pf_consultations_only <- pf_consultations_clean %>%
 pf_conditions_only <- pf_consultations_clean %>%
   filter(
     measure_type == "clinical_condition",
-    interval_start >= as.Date("2024-02-01",
-    group_type == "Overall")
+    interval_start >= as.Date("2024-02-01", group_type == "Overall")
   )
 
 dir.create(here("output", "user_tables"))

--- a/analysis/create_monthly_tables.R
+++ b/analysis/create_monthly_tables.R
@@ -52,7 +52,8 @@ pf_consultations_only <- pf_consultations_clean %>%
 pf_conditions_only <- pf_consultations_clean %>%
   filter(
     measure_type == "clinical_condition",
-    interval_start >= as.Date("2024-02-01")
+    interval_start >= as.Date("2024-02-01",
+    group_type == "Overall")
   )
 
 dir.create(here("output", "user_tables"))
@@ -64,7 +65,7 @@ readr::write_csv(
 
 readr::write_csv(
   pf_conditions_only,
-  here::here("output", "user_tables", "pf_conditions_with_breakdowns.csv")
+  here::here("output", "user_tables", "pf_conditions.csv")
 )
 
 readr::write_csv(

--- a/analysis/create_monthly_tables.R
+++ b/analysis/create_monthly_tables.R
@@ -53,7 +53,8 @@ pf_consultations_only <- pf_consultations_clean %>%
 pf_conditions_only <- pf_consultations_clean %>%
   filter(
     measure_type == "clinical_condition",
-    interval_start >= as.Date("2024-02-01", group_type == "Overall")
+    interval_start >= as.Date("2024-02-01"), 
+    group_type == "Overall"
   )
 
 dir.create(here("output", "user_tables"))

--- a/project.yaml
+++ b/project.yaml
@@ -125,5 +125,5 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/user_tables/pf_consultations_with_breakdowns.csv
-        dataset1: output/user_tables/pf_conditions_with_breakdowns.csv
+        dataset1: output/user_tables/pf_conditions.csv
         dataset2: output/user_tables/pf_completeness.csv


### PR DESCRIPTION
The clinical conditions csv is still too long. So we have filtered the csv to only include group_type == "Overall". 
This means there are no longer than breakdowns for clinical conditions, which is consistent with the PF report. 